### PR TITLE
Test 8.5.3,8.6.1 logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ### Changed
 
-- Changed output of failure reason and details for 8.5.3 to be in line with other tests.
+- Changed output of failure reason and details for 8.5.3 and 8.6.1 to be in line with other tests.
 
 ## [0.1.14] - 2024-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ### Fixed
 
-- Fixed test 8.6.1 to include all of the following properties in it's checks and output: ReportJunkToCustomizedAddress, ReportNotJunkToCustomizedAddress, ReportPhishToCustomizedAddress,ReportJunkAddresses,ReportNotJunkAddresses,ReportPhishAddresses,ReportChatMessageEnabled,ReportChatMessageToCustomizedAddressEnabled
-- Help about_M365FoundationsCISReport examples.
+- Fixed test 8.6.1 to include all of the following properties in it's checks and output: `ReportJunkToCustomizedAddress`, `ReportNotJunkToCustomizedAddress`, `ReportPhishToCustomizedAddress`,`ReportJunkAddresses`,`ReportNotJunkAddresses`,`ReportPhishAddresses`,`ReportChatMessageEnabled`,`ReportChatMessageToCustomizedAddressEnabled`
+- Fixed help `about_M365FoundationsCISReport` examples.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed test 8.6.1 to include all of the following properties in it's checks and output: ReportJunkToCustomizedAddress, ReportNotJunkToCustomizedAddress, ReportPhishToCustomizedAddress,ReportJunkAddresses,ReportNotJunkAddresses,ReportPhishAddresses,ReportChatMessageEnabled,ReportChatMessageToCustomizedAddressEnabled
+
+### Changed
+
+- Changed output of failure reason and details for 8.5.3 to be in line with other tests.
+
 ## [0.1.14] - 2024-06-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 - Fixed test 8.6.1 to include all of the following properties in it's checks and output: `ReportJunkToCustomizedAddress`, `ReportNotJunkToCustomizedAddress`, `ReportPhishToCustomizedAddress`,`ReportJunkAddresses`,`ReportNotJunkAddresses`,`ReportPhishAddresses`,`ReportChatMessageEnabled`,`ReportChatMessageToCustomizedAddressEnabled`
 - Fixed help `about_M365FoundationsCISReport` examples.
+- Fixed `Export-M365SecurityAuditTable` to properly export when nested table tests are not included.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on and uses the types of changes according to [Keep a Change
 ### Fixed
 
 - Fixed test 8.6.1 to include all of the following properties in it's checks and output: ReportJunkToCustomizedAddress, ReportNotJunkToCustomizedAddress, ReportPhishToCustomizedAddress,ReportJunkAddresses,ReportNotJunkAddresses,ReportPhishAddresses,ReportChatMessageEnabled,ReportChatMessageToCustomizedAddressEnabled
+- Help about_M365FoundationsCISReport examples.
 
 ### Changed
 

--- a/help/about_M365FoundationsCISReport.md
+++ b/help/about_M365FoundationsCISReport.md
@@ -16,23 +16,23 @@ The module includes functionality to synchronize audit results with CIS benchmar
 
 # EXAMPLES
 ```powershell
-# Example 1: Exporting a security audit table to a CSV file
-Export-M365SecurityAuditTable -OutputPath "C:\AuditReports\SecurityAudit.csv"
+# Example 1: Performing a security audit based on CIS benchmarks
+$auditResults = Invoke-M365SecurityAudit -TenantAdminUrl "https://contoso-admin.sharepoint.com"
 
-# Example 2: Retrieving licenses for users in administrative roles
-Get-AdminRoleUserLicense -RoleName "Global Administrator"
+# Example 2: Exporting a security audit table to a CSV file
+Export-M365SecurityAuditTable -ExportAllTests -AuditResults $auditResults -ExportPath "C:\temp" -ExportOriginalTests
 
-# Example 3: Getting MFA status of users
-Get-MFAStatus -UserPrincipalName "user@domain.com"
+# Example 3: Retrieving licenses for users in administrative roles
+Get-AdminRoleUserLicense
 
-# Example 4: Performing a security audit based on CIS benchmarks
-Invoke-M365SecurityAudit -OutputPath "C:\AuditReports\AuditResults.xlsx"
+# Example 4: Getting MFA status of users
+Get-MFAStatus -UserId "user@domain.com"
 
 # Example 5: Removing rows with empty status values from a CSV file
-Remove-RowsWithEmptyCSVStatus -InputPath "C:\AuditReports\AuditResults.csv" -OutputPath "C:\AuditReports\CleanedResults.csv"
+Remove-RowsWithEmptyCSVStatus -FilePath "C:\Reports\Report.xlsx" -WorksheetName "Sheet1"
 
 # Example 6: Synchronizing CIS benchmark data with audit results
-Sync-CISExcelAndCsvData -ExcelPath "C:\CISBenchmarks\CISBenchmark.xlsx" -CsvPath "C:\AuditReports\AuditResults.csv"
+Sync-CISExcelAndCsvData -ExcelPath "path\to\excel.xlsx" -CsvPath "path\to\data.csv" -SheetName "Combined Profiles"
 ```
 
 # NOTE

--- a/helpers/Build-Help.ps1
+++ b/helpers/Build-Help.ps1
@@ -37,6 +37,6 @@ $parameters = @{
     LogPath = ".\log.txt"
     Encoding = [System.Text.Encoding]::UTF8
 }
-Update-MarkdownHelpModule @parameters
-Update-MarkdownHelpModule -Path ".\help" -RefreshModulePage
+Update-MarkdownHelpModule @parameters -Force
+Update-MarkdownHelpModule -Path ".\help" -RefreshModulePage -Force
 New-ExternalHelp -Path ".\help" -OutputPath ".\source\en-US" -force

--- a/source/Private/Get-CISExoOutput.ps1
+++ b/source/Private/Get-CISExoOutput.ps1
@@ -284,7 +284,7 @@ function Get-CISExoOutput {
                 # Retrieve the necessary settings for Teams and Exchange Online
                 # Condition B: Verify that 'Monitor reported messages in Microsoft Teams' is checked in the Microsoft 365 Defender portal.
                 # Condition C: Ensure the 'Send reported messages to' setting in the Microsoft 365 Defender portal is set to 'My reporting mailbox only' with the correct report email addresses.
-                $ReportSubmissionPolicy = Get-ReportSubmissionPolicy | Select-Object -Property ReportJunkToCustomizedAddress, ReportNotJunkToCustomizedAddress, ReportPhishToCustomizedAddress, ReportChatMessageToCustomizedAddressEnabled
+                $ReportSubmissionPolicy = Get-ReportSubmissionPolicy | Select-Object -Property ReportJunkToCustomizedAddress, ReportNotJunkToCustomizedAddress, ReportPhishToCustomizedAddress,ReportJunkAddresses,ReportNotJunkAddresses,ReportPhishAddresses,ReportChatMessageEnabled,ReportChatMessageToCustomizedAddressEnabled
                 return $ReportSubmissionPolicy
             }
             default { throw "No match found for test: $Rec" }

--- a/source/Public/Export-M365SecurityAuditTable.ps1
+++ b/source/Public/Export-M365SecurityAuditTable.ps1
@@ -191,7 +191,7 @@ function Export-M365SecurityAuditTable {
         }
         else {
             if ($ExportOriginalTests) {
-                Write-Information "No specified tests were included in the export other than the full audit results." -InformationAction Continue
+                Write-Information "Full audit results exported however, none of the following tests had exports: `n1.1.1, 1.3.1, 6.1.2, 6.1.3, 7.3.4" -InformationAction Continue
             }
             else {
                 Write-Information "No specified tests were included in the export." -InformationAction Continue
@@ -201,9 +201,12 @@ function Export-M365SecurityAuditTable {
         if ($ExportOriginalTests) {
             # Define the test numbers to check
             $TestNumbersToCheck = "1.1.1", "1.3.1", "6.1.2", "6.1.3", "7.3.4"
-
-            # Check for large details and update the AuditResults array
-            $updatedAuditResults = Get-ExceededLengthResultDetail -AuditResults $AuditResults -TestNumbersToCheck $TestNumbersToCheck -ExportedTests $exportedTests -DetailsLengthLimit 30000 -PreviewLineCount 25
+            if ($exportedTests.Count -gt 0) {
+                $updatedAuditResults = Get-ExceededLengthResultDetail -AuditResults $AuditResults -TestNumbersToCheck $TestNumbersToCheck -ExportedTests $exportedTests -DetailsLengthLimit 30000 -PreviewLineCount 25
+            }
+            else {
+                $updatedAuditResults = $auditResults
+            }
             $originalFileName = "$ExportPath\$timestamp`_M365FoundationsAudit.csv"
             if ($ExportToExcel) {
                 $xlsxPath = [System.IO.Path]::ChangeExtension($originalFileName, '.xlsx')

--- a/source/en-US/about_M365FoundationsCISReport.help.txt
+++ b/source/en-US/about_M365FoundationsCISReport.help.txt
@@ -28,23 +28,23 @@ Optional Subtopics
     is always up-to-date with the latest audit findings.
 
 EXAMPLES
-    # Example 1: Exporting a security audit table to a CSV file
-    Export-M365SecurityAuditTable -OutputPath "C:\AuditReports\SecurityAudit.csv"
+    # Example 1: Performing a security audit based on CIS benchmarks
+    $auditResults = Invoke-M365SecurityAudit -TenantAdminUrl "https://contoso-admin.sharepoint.com"
     
-    # Example 2: Retrieving licenses for users in administrative roles
-    Get-AdminRoleUserLicense -RoleName "Global Administrator"
+    # Example 2: Exporting a security audit table to a CSV file
+    Export-M365SecurityAuditTable -ExportAllTests -AuditResults $auditResults -ExportPath "C:\temp" -ExportOriginalTests
     
-    # Example 3: Getting MFA status of users
-    Get-MFAStatus -UserPrincipalName "user@domain.com"
+    # Example 3: Retrieving licenses for users in administrative roles
+    Get-AdminRoleUserLicense
     
-    # Example 4: Performing a security audit based on CIS benchmarks
-    Invoke-M365SecurityAudit -OutputPath "C:\AuditReports\AuditResults.xlsx"
+    # Example 4: Getting MFA status of users
+    Get-MFAStatus -UserId "user@domain.com"
     
     # Example 5: Removing rows with empty status values from a CSV file
-    Remove-RowsWithEmptyCSVStatus -InputPath "C:\AuditReports\AuditResults.csv" -OutputPath "C:\AuditReports\CleanedResults.csv"
+    Remove-RowsWithEmptyCSVStatus -FilePath "C:\Reports\Report.xlsx" -WorksheetName "Sheet1"
     
     # Example 6: Synchronizing CIS benchmark data with audit results
-    Sync-CISExcelAndCsvData -ExcelPath "C:\CISBenchmarks\CISBenchmark.xlsx" -CsvPath "C:\AuditReports\AuditResults.csv"
+    Sync-CISExcelAndCsvData -ExcelPath "path\to\excel.xlsx" -CsvPath "path\to\data.csv" -SheetName "Combined Profiles"
 
 NOTE
     Ensure that you have the necessary permissions and administrative roles in

--- a/source/tests/Test-OrgOnlyBypassLobby.ps1
+++ b/source/tests/Test-OrgOnlyBypassLobby.ps1
@@ -39,22 +39,20 @@ function Test-OrgOnlyBypassLobby {
 
             # Prepare failure reasons and details based on compliance
             $failureReasons = if (-not $lobbyBypassRestricted) {
-                # Condition A: The `AutoAdmittedUsers` setting in the Teams meeting policy is not set to `EveryoneInCompanyExcludingGuests`.
-                "External participants can bypass the lobby"
-            }
-            else {
+                # Condition C: Verification using the Microsoft Teams admin center indicates that the meeting join & lobby settings are not configured as recommended.
+                "AutoAdmittedUsers is set to $($CsTeamsMeetingPolicyLobby.AutoAdmittedUsers)"
+
+            }else {
                 "N/A"
             }
 
             $details = if ($lobbyBypassRestricted) {
                 # Condition B: The setting for "Who can bypass the lobby" is configured to "People in my org" using the UI.
                 "Only people in the organization can bypass the lobby."
+            }else {
+                # Condition A: The `AutoAdmittedUsers` setting in the Teams meeting policy is not set to `EveryoneInCompanyExcludingGuests`.
+                "External participants can bypass the lobby"
             }
-            else {
-                # Condition C: Verification using the Microsoft Teams admin center indicates that the meeting join & lobby settings are not configured as recommended.
-                "AutoAdmittedUsers is set to $($CsTeamsMeetingPolicyLobby.AutoAdmittedUsers)"
-            }
-
             # Create and populate the CISAuditResult object
             $params = @{
                 Rec           = $recnum

--- a/source/tests/Test-ReportSecurityInTeams.ps1
+++ b/source/tests/Test-ReportSecurityInTeams.ps1
@@ -30,21 +30,51 @@ function Test-ReportSecurityInTeams {
             $ReportSubmissionPolicy.ReportJunkToCustomizedAddress -and
             $ReportSubmissionPolicy.ReportNotJunkToCustomizedAddress -and
             $ReportSubmissionPolicy.ReportPhishToCustomizedAddress -and
-            $ReportSubmissionPolicy.ReportChatMessageToCustomizedAddressEnabled
+            $null -ne $ReportSubmissionPolicy.ReportJunkAddresses -and
+            $null -ne $ReportSubmissionPolicy.ReportNotJunkAddresses -and
+            $null -ne $ReportSubmissionPolicy.ReportPhishAddresses -and
+            $ReportSubmissionPolicy.ReportChatMessageToCustomizedAddressEnabled -and
+            -not $ReportSubmissionPolicy.ReportChatMessageEnabled
 
+            $faildetailstring = @"
+The following settings are required for users to report security concerns in Teams:
+
+MS Teams:
+AllowSecurityEndUserReporting: True
+
+EXO:
+ReportJunkToCustomizedAddress               : True
+ReportNotJunkToCustomizedAddress            : True
+ReportPhishToCustomizedAddress              : True
+ReportJunkAddresses                         : <security@contoso.com>
+ReportNotJunkAddresses                      : <security@contoso.com>
+ReportPhishAddresses                        : <security@contoso.com>
+ReportChatMessageEnabled                    : False
+ReportChatMessageToCustomizedAddressEnabled : True
+"@
+            $detailsString = "Users cannot report security concerns in Teams due to one or more incorrect settings:`n`n" +
+            "MSTeams: AllowSecurityEndUserReporting: $($CsTeamsMessagingPolicy.AllowSecurityEndUserReporting); `n" +
+            "EXO: ReportJunkToCustomizedAddress: $($ReportSubmissionPolicy.ReportJunkToCustomizedAddress); `n" +
+            "EXO: ReportNotJunkToCustomizedAddress: $($ReportSubmissionPolicy.ReportNotJunkToCustomizedAddress); `n" +
+            "EXO: ReportPhishToCustomizedAddress: $($ReportSubmissionPolicy.ReportPhishToCustomizedAddress); `n" +
+            "EXO: ReportJunkAddresses: $($ReportSubmissionPolicy.ReportJunkAddresses -join ', '); `n" +
+            "EXO: ReportNotJunkAddresses: $($ReportSubmissionPolicy.ReportNotJunkAddresses -join ', '); `n" +
+            "EXO: ReportPhishAddresses: $($ReportSubmissionPolicy.ReportPhishAddresses -join ', '); `n" +
+            "EXO: ReportChatMessageEnabled: $($ReportSubmissionPolicy.ReportChatMessageEnabled); `n" +
+            "EXO: ReportChatMessageToCustomizedAddressEnabled: $($ReportSubmissionPolicy.ReportChatMessageToCustomizedAddressEnabled); "
             # Prepare failure reasons and details based on compliance
             $failureReasons = if (-not $securityReportEnabled) {
-                "Users cannot report security concerns in Teams due to one or more incorrect settings"
+                $detailsString
             }
             else {
                 "N/A"
             }
-
-            $details = "AllowSecurityEndUserReporting: $($CsTeamsMessagingPolicy.AllowSecurityEndUserReporting); " +
-            "ReportJunkToCustomizedAddress: $($ReportSubmissionPolicy.ReportJunkToCustomizedAddress); " +
-            "ReportNotJunkToCustomizedAddress: $($ReportSubmissionPolicy.ReportNotJunkToCustomizedAddress); " +
-            "ReportPhishToCustomizedAddress: $($ReportSubmissionPolicy.ReportPhishToCustomizedAddress); " +
-            "ReportChatMessageToCustomizedAddressEnabled: $($ReportSubmissionPolicy.ReportChatMessageToCustomizedAddressEnabled)"
+            $details = if ($securityReportEnabled) {
+                "Users can report security concerns in Teams."
+            }
+            else {
+                $faildetailstring
+            }
 
             # Create and populate the CISAuditResult object
             $params = @{

--- a/source/tests/Test-ReportSecurityInTeams.ps1
+++ b/source/tests/Test-ReportSecurityInTeams.ps1
@@ -36,32 +36,32 @@ function Test-ReportSecurityInTeams {
             $ReportSubmissionPolicy.ReportChatMessageToCustomizedAddressEnabled -and
             -not $ReportSubmissionPolicy.ReportChatMessageEnabled
 
-            $faildetailstring = @"
+            $detailsString = @"
 The following settings are required for users to report security concerns in Teams:
 
 MS Teams:
 AllowSecurityEndUserReporting: True
 
 EXO:
-ReportJunkToCustomizedAddress               : True
-ReportNotJunkToCustomizedAddress            : True
-ReportPhishToCustomizedAddress              : True
-ReportJunkAddresses                         : <security@contoso.com>
-ReportNotJunkAddresses                      : <security@contoso.com>
-ReportPhishAddresses                        : <security@contoso.com>
-ReportChatMessageEnabled                    : False
-ReportChatMessageToCustomizedAddressEnabled : True
+ReportJunkToCustomizedAddress: True
+ReportNotJunkToCustomizedAddress: True
+ReportPhishToCustomizedAddress: True
+ReportJunkAddresses: <security@contoso.com>
+ReportNotJunkAddresses: <security@contoso.com>
+ReportPhishAddresses: <security@contoso.com>
+ReportChatMessageEnabled: False
+ReportChatMessageToCustomizedAddressEnabled: True
 "@
-            $detailsString = "Users cannot report security concerns in Teams due to one or more incorrect settings:`n`n" +
-            "MSTeams: AllowSecurityEndUserReporting: $($CsTeamsMessagingPolicy.AllowSecurityEndUserReporting); `n" +
-            "EXO: ReportJunkToCustomizedAddress: $($ReportSubmissionPolicy.ReportJunkToCustomizedAddress); `n" +
-            "EXO: ReportNotJunkToCustomizedAddress: $($ReportSubmissionPolicy.ReportNotJunkToCustomizedAddress); `n" +
-            "EXO: ReportPhishToCustomizedAddress: $($ReportSubmissionPolicy.ReportPhishToCustomizedAddress); `n" +
-            "EXO: ReportJunkAddresses: $($ReportSubmissionPolicy.ReportJunkAddresses -join ', '); `n" +
-            "EXO: ReportNotJunkAddresses: $($ReportSubmissionPolicy.ReportNotJunkAddresses -join ', '); `n" +
-            "EXO: ReportPhishAddresses: $($ReportSubmissionPolicy.ReportPhishAddresses -join ', '); `n" +
-            "EXO: ReportChatMessageEnabled: $($ReportSubmissionPolicy.ReportChatMessageEnabled); `n" +
-            "EXO: ReportChatMessageToCustomizedAddressEnabled: $($ReportSubmissionPolicy.ReportChatMessageToCustomizedAddressEnabled); "
+            $faildetailstring = "Users cannot report security concerns in Teams due to one or more  of the found incorrect settings:`n`n" +
+            "MSTeams: `nAllowSecurityEndUserReporting: $($CsTeamsMessagingPolicy.AllowSecurityEndUserReporting); `n`n" +
+            "EXO: `nReportJunkToCustomizedAddress: $($ReportSubmissionPolicy.ReportJunkToCustomizedAddress); `n" +
+            "ReportNotJunkToCustomizedAddress: $($ReportSubmissionPolicy.ReportNotJunkToCustomizedAddress); `n" +
+            "ReportPhishToCustomizedAddress: $($ReportSubmissionPolicy.ReportPhishToCustomizedAddress); `n" +
+            "ReportJunkAddresses: $($ReportSubmissionPolicy.ReportJunkAddresses -join ', '); `n" +
+            "ReportNotJunkAddresses: $($ReportSubmissionPolicy.ReportNotJunkAddresses -join ', '); `n" +
+            "ReportPhishAddresses: $($ReportSubmissionPolicy.ReportPhishAddresses -join ', '); `n" +
+            "ReportChatMessageEnabled: $($ReportSubmissionPolicy.ReportChatMessageEnabled); `n" +
+            "ReportChatMessageToCustomizedAddressEnabled: $($ReportSubmissionPolicy.ReportChatMessageToCustomizedAddressEnabled); "
             # Prepare failure reasons and details based on compliance
             $failureReasons = if (-not $securityReportEnabled) {
                 $detailsString


### PR DESCRIPTION
### Fixed

- Fixed test 8.6.1 to include all of the following properties in it's checks and output: `ReportJunkToCustomizedAddress`, `ReportNotJunkToCustomizedAddress`, `ReportPhishToCustomizedAddress`,`ReportJunkAddresses`,`ReportNotJunkAddresses`,`ReportPhishAddresses`,`ReportChatMessageEnabled`,`ReportChatMessageToCustomizedAddressEnabled`
- Fixed help `about_M365FoundationsCISReport` examples.
- Fixed `Export-M365SecurityAuditTable` to properly export when nested table tests are not included.

### Changed

- Changed output of failure reason and details for 8.5.3 and 8.6.1 to be in line with other tests.