### PR TITLE
Revert export table change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Get-ExceededLengthResultDetail` function paramter validation for Exported Tests to allow for Null.
+
+## [0.1.16] - 2024-06-26
+
 ### Added
 
 - Added `Grant-M365SecurityAuditConsent` function to consent to the Microsoft Graph Powershell API for a user.

--- a/helpers/Build-Help.ps1
+++ b/helpers/Build-Help.ps1
@@ -4,7 +4,7 @@ Import-Module .\output\module\M365FoundationsCISReport\*\*.psd1
 
 
 <#
-    $ver = "v0.1.15"
+    $ver = "v0.1.16"
     git checkout main
     git pull origin main
     git tag -a $ver -m "Release version $ver refactor Update"

--- a/source/Private/Get-ExceededLengthResultDetail.ps1
+++ b/source/Private/Get-ExceededLengthResultDetail.ps1
@@ -9,7 +9,7 @@ function Get-ExceededLengthResultDetail {
         [Parameter(Mandatory = $true, ParameterSetName = 'ReturnExceedingTests')]
         [string[]]$TestNumbersToCheck,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'UpdateArray')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'UpdateArray')]
         [string[]]$ExportedTests,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'ReturnExceedingTests')]

--- a/source/Public/Export-M365SecurityAuditTable.ps1
+++ b/source/Public/Export-M365SecurityAuditTable.ps1
@@ -61,8 +61,8 @@ function Export-M365SecurityAuditTable {
         [ValidateSet("1.1.1", "1.3.1", "6.1.2", "6.1.3", "7.3.4")]
         [string]$OutputTestNumber,
 
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "ExportAllResultsFromAuditResults")]
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "ExportAllResultsFromCsv")]
+        [Parameter(Mandatory = $false, Position = 0, ParameterSetName = "ExportAllResultsFromAuditResults")]
+        [Parameter(Mandatory = $false, Position = 0, ParameterSetName = "ExportAllResultsFromCsv")]
         [switch]$ExportAllTests,
 
         [Parameter(Mandatory = $true, ParameterSetName = "ExportAllResultsFromAuditResults")]

--- a/source/Public/Export-M365SecurityAuditTable.ps1
+++ b/source/Public/Export-M365SecurityAuditTable.ps1
@@ -201,12 +201,9 @@ function Export-M365SecurityAuditTable {
         if ($ExportOriginalTests) {
             # Define the test numbers to check
             $TestNumbersToCheck = "1.1.1", "1.3.1", "6.1.2", "6.1.3", "7.3.4"
-            if ($exportedTests.Count -gt 0) {
-                $updatedAuditResults = Get-ExceededLengthResultDetail -AuditResults $AuditResults -TestNumbersToCheck $TestNumbersToCheck -ExportedTests $exportedTests -DetailsLengthLimit 30000 -PreviewLineCount 25
-            }
-            else {
-                $updatedAuditResults = $auditResults
-            }
+
+            # Check for large details and update the AuditResults array
+            $updatedAuditResults = Get-ExceededLengthResultDetail -AuditResults $AuditResults -TestNumbersToCheck $TestNumbersToCheck -ExportedTests $exportedTests -DetailsLengthLimit 30000 -PreviewLineCount 25
             $originalFileName = "$ExportPath\$timestamp`_M365FoundationsAudit.csv"
             if ($ExportToExcel) {
                 $xlsxPath = [System.IO.Path]::ChangeExtension($originalFileName, '.xlsx')


### PR DESCRIPTION
### Fixed

- Fixed `Get-ExceededLengthResultDetail` function paramter validation for Exported Tests to allow for Null.